### PR TITLE
Local package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
     "dbstart": "cd database && docker-compose up -d",
     "dbbackup": "docker exec -it database bash -c 'pg_dump -U directus -W -F t directus > ./backup/database_dump.pg'",
     "cmstart": "cd cms && docker-compose up -d",
-    "start": "cd database && docker-compose up -d && cd ../cms && docker-compose up -d",
-    "stop": "cd cms && docker-compose down && cd ../database && docker-compose down && npx kill-port 8080",
+    "start": "npm run ascii && cd database && docker-compose up -d && cd ../cms && docker-compose up -d && cd ../ && npm run frontend && echo \"$(tput setaf 3)Use $(tput setaf 1)npm run dbrestore $(tput setaf 3)to restore the database. \" && echo \"Use $(tput setaf 1)npm run restart$(tput setaf 3) to restart after the restore.\" && echo \"\" && echo \"$(tput sgr0)Database started successfully. Located at http://localhost:5432\" && echo \"CMS started successfully. Located at http://localhost:8055\" && echo \"Frontend started successfully. Located at http://localhost:8080\"",
+    "stop": "npm run ascii && cd cms && docker-compose down && cd ../database && docker-compose down && npx kill-port 8080 && echo \"Datbase, CMS, and Frontend stopped successfully.\"",
+    "restart": "npm run stop && npm run start",
     "clean": "cd database && docker-compose down --rmi all --volumes --remove-orphans && docker-compose up -d && cd ../cms docker-compose down --rmi all --volumes --remove-orphans && docker-compose up -d",
-    "dbrestore": "docker exec -it database bash -c 'pg_restore -U directus --clean --no-owner --no-acl --dbname=directus ./backup/dev_database_backup.pg' && docker compose down && docker compose up -d",
+    "dbrestore": "docker exec -it database bash -c 'pg_restore -U directus --clean --no-owner --no-acl --dbname=directus ./backup/dev_database_backup.pg'",
     "psql": "docker exec -it database bash",
-    "frontend": "cd frontend && nohup npm run serve > /dev/null 2>&1 &"
+    "frontend": "cd frontend && nohup npm run serve > /dev/null 2>&1 &",
+    "ascii": "clear && echo \" ██████╗ ███╗   ██╗██████╗ ██████╗ \" && echo \"██╔═══██╗████╗  ██║██╔══██╗██╔══██╗\" && echo \"██║   ██║██╔██╗ ██║██████╔╝██████╔╝\" && echo \"██║   ██║██║╚██╗██║██╔══██╗██╔══██╗\" && echo \"╚██████╔╝██║ ╚████║██║  ██║██║  ██║\" && echo \" ╚═════╝ ╚═╝  ╚═══╝╚═╝  ╚═╝╚═╝  ╚═╝\" && echo \"_______________________________________________________________\"",
+    "clear": "npm run ascii && cd database && docker-compose down --rmi all --volumes --remove-orphans && cd ../cms && docker-compose down --rmi all --volumes --remove-orphans && npx kill-port 8080 && echo \"Database and CMS cleared successfully.\""
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "stop": "npm run ascii && cd cms && docker-compose down && cd ../database && docker-compose down && npx kill-port 8080 && echo \"Datbase, CMS, and Frontend stopped successfully.\"",
     "restart": "npm run stop && npm run start",
     "clean": "cd database && docker-compose down --rmi all --volumes --remove-orphans && docker-compose up -d && cd ../cms docker-compose down --rmi all --volumes --remove-orphans && docker-compose up -d",
-    "dbrestore": "docker exec -it database bash -c 'pg_restore -U directus --clean --no-owner --no-acl --dbname=directus ./backup/dev_database_backup.pg'",
+    "dbrestore": "docker exec -it database bash -c 'pg_restore -U directus --clean --no-owner --no-acl --dbname=directus ./backup/dev_database_backup.pg' || echo $?",
     "psql": "docker exec -it database bash",
     "frontend": "cd frontend && nohup npm run serve > /dev/null 2>&1 &",
     "ascii": "clear && echo \" ██████╗ ███╗   ██╗██████╗ ██████╗ \" && echo \"██╔═══██╗████╗  ██║██╔══██╗██╔══██╗\" && echo \"██║   ██║██╔██╗ ██║██████╔╝██████╔╝\" && echo \"██║   ██║██║╚██╗██║██╔══██╗██╔══██╗\" && echo \"╚██████╔╝██║ ╚████║██║  ██║██║  ██║\" && echo \" ╚═════╝ ╚═╝  ╚═══╝╚═╝  ╚═╝╚═╝  ╚═╝\" && echo \"_______________________________________________________________\"",
-    "clear": "npm run ascii && cd database && docker-compose down --rmi all --volumes --remove-orphans && cd ../cms && docker-compose down --rmi all --volumes --remove-orphans && npx kill-port 8080 && echo \"Database and CMS cleared successfully.\""
+    "clear": "npm run ascii && cd database && docker-compose down --rmi all --volumes --remove-orphans && cd ../cms && docker-compose down --rmi all --volumes --remove-orphans && npx kill-port 8080 && echo \"Database and CMS cleared successfully.\"",
+    "init": "npm run ascii && cd database && docker-compose up -d && cd ../cms && docker-compose up -d && cd ../ && npm run dbrestore && npm run frontend && echo \"$(tput setaf 3)Use $(tput setaf 1)npm run dbrestore $(tput setaf 3)to restore the database. \" && echo \"Use $(tput setaf 1)npm run restart$(tput setaf 3) to restart after the restore.\" && echo \"\" && echo \"$(tput sgr0)Database started successfully. Located at http://localhost:5432\" && echo \"CMS started successfully. Located at http://localhost:8055\" && echo \"Frontend started successfully. Located at http://localhost:8080\""
+    
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "onrr.gov-site",
+  "version": "0.1.0",
+  "author": "Chris Robey <robey.christopher98@gmail.com>",
+
+  "scripts": {
+    "test": "echo \"test\"",
+    "dbstart": "cd database && docker-compose up -d",
+    "dbbackup": "docker exec -it database bash -c 'pg_dump -U directus -W -F t directus > ./backup/database_dump.pg'",
+    "cmstart": "cd cms && docker-compose up -d",
+    "start": "cd database && docker-compose up -d && cd ../cms && docker-compose up -d",
+    "stop": "cd cms && docker-compose down && cd ../database && docker-compose down && npx kill-port 8080",
+    "clean": "cd database && docker-compose down --rmi all --volumes --remove-orphans && docker-compose up -d && cd ../cms docker-compose down --rmi all --volumes --remove-orphans && docker-compose up -d",
+    "dbrestore": "docker exec -it database bash -c 'pg_restore -U directus --clean --no-owner --no-acl --dbname=directus ./backup/dev_database_backup.pg' && docker compose down && docker compose up -d",
+    "psql": "docker exec -it database bash",
+    "frontend": "cd frontend && nohup npm run serve > /dev/null 2>&1 &"
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "author": "Chris Robey <robey.christopher98@gmail.com>",
 
   "scripts": {
-    "test": "echo \"test\"",
     "dbstart": "cd database && docker-compose up -d",
     "dbbackup": "docker exec -it database bash -c 'pg_dump -U directus -W -F t directus > ./backup/database_dump.pg'",
     "cmstart": "cd cms && docker-compose up -d",


### PR DESCRIPTION
Added a package.json file. Scripts include:

- dbstart: Starts database
- dbbackup: Backs up the database
- cmstart: Starts the cms
- start: Starts both the database and the cms
- stop: Stops the database, cms, and kills the frontend
- clean: Clean start of both the database and cms
- dbrestore: Restores the database backup
- psql: docker exec -it database bash (This was in the cms package scripts so I wasn't sure if this needed to be kept here too)
- frontend: Starts the frontend

Created and tested in Ubuntu 20.04