### PR TITLE
2850-nrrd-link-mobile: Fixes href issue.

### DIFF
--- a/frontend/src/components/toolbars/AppToolbar.vue
+++ b/frontend/src/components/toolbars/AppToolbar.vue
@@ -100,7 +100,7 @@
           <v-list-item
             v-for="item in utilityItems"
             :key="item.id"
-            :to="`${ item.custom_url || item.link_to_page.url }`"
+            :href="item.custom_url || item.link_to_page.url"
           >
             <v-list-item-icon>
               <v-icon v-text="item.menu_icon"></v-icon>


### PR DESCRIPTION
The solution for this problem was to use a different attribute for the v-list-item attribute. `to` was previously used and was prepending the URL with `/`. I changed the code to use the `href` attribute. 

There was no issue with the standard header menu because it was rendering the links as buttons.